### PR TITLE
Implement password encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,5 +64,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.14.2</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.password4j/password4j -->
+        <dependency>
+            <groupId>com.password4j</groupId>
+            <artifactId>password4j</artifactId>
+            <version>1.7.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/pet/project/servlet/SignInServlet.java
+++ b/src/main/java/pet/project/servlet/SignInServlet.java
@@ -1,5 +1,6 @@
 package pet.project.servlet;
 
+import com.password4j.Password;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -51,7 +52,9 @@ public class SignInServlet extends HttpServlet {
         Optional<User> optionalUser = userDao.findByLogin(login);
         User user = optionalUser.orElseThrow();
 
-        if (!user.getPassword().equals(password)) {
+        String passwordFromDb = user.getPassword();
+
+        if (!Password.check(password, passwordFromDb).withBcrypt()) {
             throw new RuntimeException("Authorization exception: wrong password");
         }
 

--- a/src/main/java/pet/project/servlet/SignUpServlet.java
+++ b/src/main/java/pet/project/servlet/SignUpServlet.java
@@ -1,5 +1,7 @@
 package pet.project.servlet;
 
+import com.password4j.Hash;
+import com.password4j.Password;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -48,7 +50,9 @@ public class SignUpServlet extends HttpServlet {
         String login = req.getParameter("login");
         String password = req.getParameter("password");
 
-        User user = new User(login, password);
+        Hash hash = Password.hash(password).withBcrypt();
+
+        User user = new User(login, hash.getResult());
 
         // TODO: Properly handle all Exceptions
         if (userDao.isPresent(user)) {


### PR DESCRIPTION
Add the bcrypt password encoding to the authentication processes.

- User password now will be stored in the database in the hash format
- Now during the credential validation process app will compare two hashes instead of two plain text passwords

Closes #2